### PR TITLE
Auction improve reliability

### DIFF
--- a/src/main/scala/mission/impossibl/bots/MissionImpossiBots.scala
+++ b/src/main/scala/mission/impossibl/bots/MissionImpossiBots.scala
@@ -15,13 +15,16 @@ object MissionImpossiBots extends App {
 
   environment ! EnvironmentSimulator.SpawnGarbageOrchestrator()
   environment ! EnvironmentSimulator.SpawnWasteSource(20, (1, 1))
+  environment ! EnvironmentSimulator.SpawnWasteSource(10, (12, 1))
+  environment ! EnvironmentSimulator.SpawnWasteSource(15, (1, 10))
+  environment ! EnvironmentSimulator.SpawnWasteSource(20, (5, 5))
   environment ! EnvironmentSimulator.SpawnWasteSink(100, 100, (20, 20))
   environment ! EnvironmentSimulator.SpawnGarbageCollector(30, (5, 5), 5)
   environment ! EnvironmentSimulator.SpawnGarbageCollector(30, (5, 5), 3)
 
   implicit val ec: ExecutionContextExecutor = system.executionContext
-  system.scheduler.scheduleAtFixedRate(10.seconds, 10.seconds)(() => environment ! EnvironmentSimulator.SourceSimulationTick())
-  system.scheduler.scheduleAtFixedRate(10.seconds, 10.seconds)(() => environment ! EnvironmentSimulator.SinkSimulationTick())
+  system.scheduler.scheduleAtFixedRate(2.seconds, 2.seconds)(() => environment ! EnvironmentSimulator.SourceSimulationTick())
+  system.scheduler.scheduleAtFixedRate(2.seconds, 2.seconds)(() => environment ! EnvironmentSimulator.SinkSimulationTick())
   system.scheduler.scheduleAtFixedRate(1.second, 1.second)(() => environment ! EnvironmentSimulator.CollectorSimulationTick())
 
   val api           = new MissionApi(environment)

--- a/src/main/scala/mission/impossibl/bots/MissionImpossiBots.scala
+++ b/src/main/scala/mission/impossibl/bots/MissionImpossiBots.scala
@@ -15,16 +15,13 @@ object MissionImpossiBots extends App {
 
   environment ! EnvironmentSimulator.SpawnGarbageOrchestrator()
   environment ! EnvironmentSimulator.SpawnWasteSource(20, (1, 1))
-  environment ! EnvironmentSimulator.SpawnWasteSource(10, (12, 1))
-  environment ! EnvironmentSimulator.SpawnWasteSource(15, (1, 10))
-  environment ! EnvironmentSimulator.SpawnWasteSource(20, (5, 5))
   environment ! EnvironmentSimulator.SpawnWasteSink(100, 100, (20, 20))
   environment ! EnvironmentSimulator.SpawnGarbageCollector(30, (5, 5), 5)
   environment ! EnvironmentSimulator.SpawnGarbageCollector(30, (5, 5), 3)
 
   implicit val ec: ExecutionContextExecutor = system.executionContext
-  system.scheduler.scheduleAtFixedRate(2.seconds, 2.seconds)(() => environment ! EnvironmentSimulator.SourceSimulationTick())
-  system.scheduler.scheduleAtFixedRate(2.seconds, 2.seconds)(() => environment ! EnvironmentSimulator.SinkSimulationTick())
+  system.scheduler.scheduleAtFixedRate(10.seconds, 10.seconds)(() => environment ! EnvironmentSimulator.SourceSimulationTick())
+  system.scheduler.scheduleAtFixedRate(10.seconds, 10.seconds)(() => environment ! EnvironmentSimulator.SinkSimulationTick())
   system.scheduler.scheduleAtFixedRate(1.second, 1.second)(() => environment ! EnvironmentSimulator.CollectorSimulationTick())
 
   val api           = new MissionApi(environment)

--- a/src/main/scala/mission/impossibl/bots/Utils.scala
+++ b/src/main/scala/mission/impossibl/bots/Utils.scala
@@ -3,11 +3,14 @@ package mission.impossibl.bots
 import scala.util.Random
 
 object Utils {
-  def sample_normal(mean: Int, sigma: Int): Int = {
+  def sampleNormal(mean: Int, sigma: Int): Int = {
     math.round(Random.nextGaussian() * sigma + mean).toInt
   }
-  def sample_normal(mean: Float, sigma: Float): Float = {
+  def sampleNormal(mean: Float, sigma: Float): Float = {
     (Random.nextGaussian() * sigma + mean).toFloat
   }
+
+  def dist(destination: (Int, Int), location: (Int, Int)): Int =
+    math.abs(destination._1 - location._1) + math.abs(destination._2 - location._2)
 }
 

--- a/src/main/scala/mission/impossibl/bots/collector/GarbageCollector.scala
+++ b/src/main/scala/mission/impossibl/bots/collector/GarbageCollector.scala
@@ -2,6 +2,7 @@ package mission.impossibl.bots.collector
 
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.typed.{ActorRef, Behavior}
+import mission.impossibl.bots.Utils.dist
 import mission.impossibl.bots.collector.GarbageCollector.Move
 import mission.impossibl.bots.http.{CollectorStatus, SourcePathElem}
 import mission.impossibl.bots.orchestrator.GarbageOrchestrator.{GarbageCollectionProposal, GarbageDisposalRequest}
@@ -19,9 +20,6 @@ object GarbageCollector {
   private val DisposalAuctionTimeoutVal = 10.seconds
 
   // todo: exchange garbage with sink
-  // todo:
-  // - ensure collector proritizes disposal when possible
-  // - should not take part in collection auctions if there is disposal point in state
   def apply(instance: Instance, initialLocation: (Int, Int)): Behavior[Command] =
     collector(instance, State(initialLocation))
 
@@ -35,44 +33,29 @@ object GarbageCollector {
 
         case GarbageCollectionCallForProposal(auctionId, sourceId, sourceLocation, garbageAmount) =>
           context.log.info("Received Garbage Collection CFP for source {} and amount {}", sourceId, garbageAmount)
-          if (state.disposalPoint.isDefined) {
-            context.log.info("Disposal point exists, ignoring auction.")
+          if (state.disposalPoint.isDefined || state.disposalAuctionTimeout.isDefined) {
+            context.log.info("Disposal point exists or disposal auction in progress, ignoring collection CFP {}.", auctionId)
             Behaviors.same
           } else {
             val emptySpace = instance.capacity - state.ongoingCollectionAuctions.values.map(_.amount).sum - state.futureSources.map(_.amount).sum
-            if (emptySpace - garbageAmount > 0) {
-              val distanceToSource = routeLen(state.currentLocation, state.futureSources, sourceLocation)
-              val auctionOffer     = CollectionAuctionOffer(context.self, when = math.ceil(distanceToSource / instance.speed).seconds)
-              instance.orchestrator ! GarbageCollectionProposal(auctionId, auctionOffer)
-              collector(
-                instance,
-                state.copy(
-                  ongoingCollectionAuctions = state.ongoingCollectionAuctions.updated(auctionId, Garbage(sourceLocation, garbageAmount))
-                )
-              )
-            } else {
-              context.log.info(
-                "{} Ignoring CFP, can't handle {} garbage, already carrying {}/{}",
-                state.auctionMissed,
-                garbageAmount,
-                state.carriedGarbage,
-                instance.capacity
-              )
-              if (state.auctionMissed == 2) {
-                context.log.info("This is the 3rd missed auction, initiating disposal")
-                val updatedState = initDisposal(instance, state, context).copy(auctionMissed = 0)
-                collector(instance, updatedState)
-              } else {
-                collector(instance, state.copy(auctionMissed = state.auctionMissed + 1))
-              }
+            if (emptySpace <= 0) {
+              context.log.warn("O free space and disposal not in progress")
             }
+            val distanceToSource = routeLen(state.currentLocation, state.futureSources, sourceLocation)
+            val estimatedArrival = math.ceil(distanceToSource / instance.speed).seconds
+            instance.orchestrator ! GarbageCollectionProposal(auctionId, CollectionAuctionOffer(context.self, estimatedArrival, emptySpace))
+            collector(
+              instance,
+              state.copy(
+                ongoingCollectionAuctions = state.ongoingCollectionAuctions.updated(auctionId, Garbage(sourceLocation, garbageAmount))
+              )
+            )
           }
-
         case GarbageCollectionAccepted(auctionId, sourceId, sourceRef) =>
           context.log.info("GC Accepted for auction id {}", auctionId)
           val garbage = state.ongoingCollectionAuctions.get(auctionId)
           if (garbage.isEmpty) {
-            context.log.info("Won action {} I don't rember of :)", auctionId)
+            context.log.warn("Won action {} I don't remember of :)", auctionId)
             Behaviors.same
           } else {
             val newNode          = GarbagePathElem(garbage.get.location, garbage.get.amount, sourceId, sourceRef)
@@ -108,9 +91,8 @@ object GarbageCollector {
           state.disposalPoint match {
             case Some(DisposalPoint(destination, sink)) =>
               val loc = move(destination, state.currentLocation, instance.speed)
-              context.log.info("Moving to disposal point {}, currently at {}, with speed {}", destination, loc, instance.speed)
               if (loc == destination) {
-                context.log.error("At destination - sink at {}", destination)
+                context.log.info("At destination - sink at {}", destination)
                 val packets = state.visitedSources.map(g => GarbagePacketRecord(g.id, wasteMass = g.amount))
                 sink ! ReceiveGarbage(GarbagePacket(packets, packets.map(_.wasteMass).sum), instance.id)
                 context.log.info("Emptied")
@@ -123,9 +105,7 @@ object GarbageCollector {
                 case Some(nextSource) =>
                   val dest = nextSource.location
                   val loc  = move(dest, state.currentLocation, instance.speed)
-                  context.log.info("Moving to source point {}, from {} to {}, with speed {}", dest, state.currentLocation, loc, instance.speed)
                   if (loc == dest) {
-                    context.log.error("At destination - source at {}", dest)
                     nextSource.ref ! DisposeGarbage(instance.capacity - state.carriedGarbage, context.self)
                   }
                   collector(instance, state.copy(currentLocation = loc))
@@ -135,7 +115,7 @@ object GarbageCollector {
           }
 
         case DisposalAuctionTimeout() =>
-          context.log.info("Disposal Auction Timeout Reached, re-initing")
+          context.log.warn("Disposal Auction Timeout Reached, re-initing")
           val updatedState = initDisposal(instance, state.copy(disposalAuctionTimeout = None), context)
           collector(instance, updatedState)
 
@@ -144,7 +124,6 @@ object GarbageCollector {
             case Some(timeout) =>
               context.log.info("Got disposal point info - moving to {}", disposalPoint.location)
               timeout.cancel()
-              // TODO: consider dropping future queue if nonempty?
               val updatedState = state.copy(disposalAuctionTimeout = None, disposalPoint = Some(disposalPoint))
               collector(instance, updatedState)
             case None => Behaviors.same // action has already timed out and was repeated
@@ -196,12 +175,9 @@ object GarbageCollector {
     updatedDistance + dist(updatedLoc, destination)
   }
 
-  private def dist(destination: (Int, Int), location: (Int, Int)): Int =
-    math.abs(destination._1 - location._1) + math.abs(destination._2 - location._2)
-
   private def initDisposal(instance: Instance, state: State, context: ActorContext[Command]): State = {
-    context.log.info("Initing disposal auction")
-    instance.orchestrator ! GarbageDisposalRequest(instance.id, state.carriedGarbage, context.self)
+    context.log.info("Init disposal auction")
+    instance.orchestrator ! GarbageDisposalRequest(instance.id, state.carriedGarbage, context.self, state.currentLocation)
     val timeout = context.scheduleOnce(DisposalAuctionTimeoutVal, context.self, DisposalAuctionTimeout())
     state.copy(disposalAuctionTimeout = Some(timeout))
   }

--- a/src/main/scala/mission/impossibl/bots/collector/GarbageCollector.scala
+++ b/src/main/scala/mission/impossibl/bots/collector/GarbageCollector.scala
@@ -19,7 +19,6 @@ object GarbageCollector {
   private val DisposalPercentFull       = 0.95
   private val DisposalAuctionTimeoutVal = 10.seconds
 
-  // todo: exchange garbage with sink
   def apply(instance: Instance, initialLocation: (Int, Int)): Behavior[Command] =
     collector(instance, State(initialLocation))
 

--- a/src/main/scala/mission/impossibl/bots/orchestrator/Models.scala
+++ b/src/main/scala/mission/impossibl/bots/orchestrator/Models.scala
@@ -48,12 +48,14 @@ final case class CollectionDetails(
 
 final case class DisposalDetails(
   garbageAmount: Int,
-  collectorId: UUID
+  collectorId: UUID,
+  location: (Int, Int)
 )
 
 final case class CollectionAuctionOffer(
-  gcRef: ActorRef[GarbageCollector.Command],
-  when: FiniteDuration
+                                         collectorRef: ActorRef[GarbageCollector.Command],
+                                         estimatedArrival: FiniteDuration,
+                                         capacity: Int
 )
 
 final case class DisposalAuctionOffer(wasteSink: ActorRef[WasteSink.Command], location: (Int, Int))

--- a/src/main/scala/mission/impossibl/bots/sink/Models.scala
+++ b/src/main/scala/mission/impossibl/bots/sink/Models.scala
@@ -10,7 +10,6 @@ final case class Garbage(amount: Int)
 
 final case class Instance(id: UUID, location: (Int, Int), storageCapacity: Int, orchestrator: ActorRef[GarbageOrchestrator.Command])
 
-//todo waste type?
 final case class GarbagePacketRecord(wasteSourceId: UUID, wasteType: Int = 0, wasteMass: Int)
 
 final case class GarbagePacket(records: List[GarbagePacketRecord], totalMass: Int)

--- a/src/main/scala/mission/impossibl/bots/source/WasteSource.scala
+++ b/src/main/scala/mission/impossibl/bots/source/WasteSource.scala
@@ -53,7 +53,7 @@ object WasteSource {
           source(instance, state.copy(collectionTimeout = Some(collectionTimeout), estimatedCollectorArrival = Some(estimatedArrival), auctionTimeout = None))
 
         case CollectionTimeout() =>
-          context.log.info("Collection Timeout")
+          context.log.warn("Collection Timeout")
           source(instance, checkGarbageLevel(state.copy(collectionTimeout = None), instance, context))
 
         case GarbageScoreSummary(garbage_score) =>

--- a/src/main/scala/mission/impossibl/bots/source/WasteSource.scala
+++ b/src/main/scala/mission/impossibl/bots/source/WasteSource.scala
@@ -48,7 +48,7 @@ object WasteSource {
 
         case GarbageCollectionInfo(collectorId, estimatedArrival) =>
           context.log.info("Collector {} will arrive in {}", collectorId, estimatedArrival)
-          state.auctionTimeout.map(_.cancel()) // todo maybe one timeout could suffice for both
+          state.auctionTimeout.map(_.cancel())
           val collectionTimeout = state.collectionTimeout.getOrElse(context.scheduleOnce(estimatedArrival + LatenessTolerance, context.self, CollectionTimeout()))
           source(instance, state.copy(collectionTimeout = Some(collectionTimeout), estimatedCollectorArrival = Some(estimatedArrival), auctionTimeout = None))
 


### PR DESCRIPTION
Collection
- collectors no longer ignore auctions where there is more garbage than free space
- choose multiple offers (as many collectors as are needed to collect all garbage from source)
- collectors will ignore collection auction if disposal timeout is defined (== disposal auction is in progress)
Disposal:
- choose sink based on closeness to garbage collector